### PR TITLE
MNT: Add noarch: python

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,3 +131,6 @@ Feedstock Maintainers
 * [@pelson](https://github.com/pelson/)
 * [@willingc](https://github.com/willingc/)
 
+
+<!-- dummy commit to enable rerendering -->
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
 
 build:
   noarch: python
+  noarch: python
   number: 0
   script: {{ PYTHON }} -m pip install . -vv
 


### PR DESCRIPTION

Hi! This is the friendly automated conda-forge-webservice.

I've made the recipe `noarch: python` as instructed in #76.


Here's a checklist to do before merging.
- [ ] Bump the build number if needed.
